### PR TITLE
Deploying a single server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # docker compose volume
 volume
+*.tfstate*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   localstack:

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,3 @@ output "public_ip" {
     value = aws_instance.example.public_ip
     description = "The public IP address of the web server"
 }
-
-
-#"LKIAQAAAAAAAFXMTDSWU"
-#"DlMa2CAr/8HPWWuD7JCy/8H9MyedBQsL7Rv/fIfD"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,4 @@
+# terraform block
 terraform {
     required_providers {
         aws = {
@@ -7,11 +8,53 @@ terraform {
     }
 }
 
+# define aws access key variables
 variable "access_key" { type = string } 
 variable "secret_key" { type = string } 
 
+# set up cloud provider
 provider "aws" {
   region = "us-east-1"
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
 }
+
+# set up EC2 virtual machine
+resource "aws_instance" "example" {
+    ami = "ami-0c55b159cbfafe1f0"
+    instance_type = "t2.micro"
+    vpc_security_group_ids = [aws_security_group.instance.id]
+    
+    user_data = <<-EOF
+    #!/bin/bash
+    echo "Hello, World" > index.html
+    nohup busybox httpd -f -p 8080 &
+    EOF
+
+    tags = {
+        Name = "terraform-example"
+    }
+}
+
+# To allow the EC2 Instance to receive traffic on port 8080, you need to create a security group
+resource "aws_security_group" "instance" {
+    name = "terraform-example-instance"
+    ingress {
+        from_port = 8080
+        to_port = 8080
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+# instead of having to manually poke around the EC2 console to
+# find the IP address of your server, you can provide the IP address as an
+# output variable
+output "public_ip" {
+    value = aws_instance.example.public_ip
+    description = "The public IP address of the web server"
+}
+
+
+#"LKIAQAAAAAAAFXMTDSWU"
+#"DlMa2CAr/8HPWWuD7JCy/8H9MyedBQsL7Rv/fIfD"


### PR DESCRIPTION
Adds an [EC2 instance](https://aws.amazon.com/es/ec2/instance-types/) to the infrastructure named "example".

`aws_instance`
The EC2 instance which is a virtual machine. The ` t2.micro` type has no cost as it is on the free tier plan on aws.

`aws_security_group`
To allow the EC2 Instance to receive traffic on port 8080, you need to create a security group.

output variable `public_ip`
instead of having to manually poke around the EC2 console to find the IP address of your server, you can provide the IP address as an output variable

### Resources
* Terraform Up & Running (Yevgeniy Brikman) - Chapter 2